### PR TITLE
Fix for inconsistent postgres db setup over TCP

### DIFF
--- a/images/postgres/init-scripts/1_init_taskdb.sh
+++ b/images/postgres/init-scripts/1_init_taskdb.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-psql -f /docker-entrypoint-initdb.d/init-task.sql.noautorun -U kinetictask_user -d TASK_DATABASE -h localhost
+psql -f /docker-entrypoint-initdb.d/init-task.sql.noautorun -U kinetictask_user -d TASK_DATABASE


### PR DESCRIPTION
This fixes the issue where Kinetic Task fails to have it's database created / schema setup.

The issue occurs because we attempt to use TCP with the psql command and the init script is ran before postgres is listening on TCP 5432 for some users.

By removing **-h localhost**, psql uses the default UNIX socket which postgres always seems to have established before the init script runs.