### PR TITLE
Perform Postgres health check with configured user

### DIFF
--- a/docker-compose-windows.yml
+++ b/docker-compose-windows.yml
@@ -22,7 +22,7 @@ services:
         POSTGRES_DB: "${POSTGRES_DB}"
         PGPASSWORD: "${PGPASSWORD}"
       healthcheck:
-        test: ["CMD-SHELL", "pg_isready -U postgres"]
+        test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
       volumes:
         - postgres_kinetic_task_db_platform:/var/lib/postgresql/data
         - ./images/postgres/init-scripts:/docker-entrypoint-initdb.d
@@ -141,7 +141,7 @@ services:
       volumes:
         - ./data/filehub/data:/home/dataDirectory
         - ./data/filehub/files:/home/filesDirectory
-        
+
 volumes:
     postgres_kinetic_task_db_platform:
         external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
         POSTGRES_DB: "${POSTGRES_DB}"
         PGPASSWORD: "${PGPASSWORD}"
       healthcheck:
-        test: ["CMD-SHELL", "pg_isready -U postgres"]
+        test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
       volumes:
         - ./data/postgres/data:/var/lib/postgresql/data
         - ./images/postgres/init-scripts:/docker-entrypoint-initdb.d


### PR DESCRIPTION
The postgres user is no longer created by default, meaning that the health check was failing to login.

The health check now uses the $POSTGRES_USER environment variable.

This change to stop the postgres user being created by default is docker-library/postgres#493