### PR TITLE
Perform Postgres health check against our database

### DIFF
--- a/docker-compose-windows.yml
+++ b/docker-compose-windows.yml
@@ -22,7 +22,7 @@ services:
         POSTGRES_DB: "${POSTGRES_DB}"
         PGPASSWORD: "${PGPASSWORD}"
       healthcheck:
-        test: ["CMD-SHELL", "pg_isready -U postgres"]
+        test: ["CMD-SHELL", "pg_isready -U postgres -d ${POSTGRES_DB}"]
       volumes:
         - postgres_kinetic_task_db_platform:/var/lib/postgresql/data
         - ./images/postgres/init-scripts:/docker-entrypoint-initdb.d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
         POSTGRES_DB: "${POSTGRES_DB}"
         PGPASSWORD: "${PGPASSWORD}"
       healthcheck:
-        test: ["CMD-SHELL", "pg_isready -U postgres"]
+        test: ["CMD-SHELL", "pg_isready -U postgres -d ${POSTGRES_DB}"]
       volumes:
         - ./data/postgres/data:/var/lib/postgresql/data
         - ./images/postgres/init-scripts:/docker-entrypoint-initdb.d


### PR DESCRIPTION
Before this change, the Postgres health check was failing with an error that the database does not exist. It was looking for a database with a name matching the $POSTGRES_USER rather than $POSTGRES_DB.